### PR TITLE
Fix Swagger UI server selection for production testing

### DIFF
--- a/config/swagger.js
+++ b/config/swagger.js
@@ -20,12 +20,12 @@ const options = {
     },
     servers: [
       {
-        url: process.env.NODE_ENV === 'production' 
-          ? 'https://user-management-k11z.onrender.com'
-          : 'http://localhost:8888',
-        description: process.env.NODE_ENV === 'production' 
-          ? 'Production server'
-          : 'Development server'
+        url: 'https://user-management-k11z.onrender.com',
+        description: 'Production server (Render)'
+      },
+      {
+        url: 'http://localhost:8888',
+        description: 'Development server'
       }
     ],
     components: {

--- a/server.js
+++ b/server.js
@@ -30,9 +30,11 @@ app.use(helmet({
 
 // Middleware
 app.use(cors({
-  origin: process.env.NODE_ENV === 'production' 
-    ? ['https://user-management-k11z.onrender.com'] 
-    : ['http://localhost:8888', 'http://127.0.0.1:8888'],
+  origin: [
+    'https://user-management-k11z.onrender.com',
+    'http://localhost:8888',
+    'http://127.0.0.1:8888'
+  ],
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'x-secret-challenge']


### PR DESCRIPTION
- Add both production and development servers to Swagger configuration
- Users can now select the correct server from dropdown in Swagger UI
- Simplify CORS to allow all environments consistently
- Resolves localhost URL issue in production Swagger documentation